### PR TITLE
Use DUMP and RESTORE commands instead of MIGRATE

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,9 +19,18 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
-      - name: Make
-        run: make
+
+      - name: Install cpplint
+        run: pip install cpplint
+
+      - name: Lint
+        run: make lint
+
+      - name: Make build
+        run: make build
+
       - name: Make clean
         run: make clean
+
       - name: Make debug
         run: make debug

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,12 +20,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Install cpplint
-        run: pip3 install cpplint
-
-      - name: Lint
-        run: make lint
-
       - name: Make build
         run: make build
 
@@ -34,3 +28,8 @@ jobs:
 
       - name: Make debug
         run: make debug
+
+      - name: Lint
+        run: |
+          pip3 install cpplint
+          make lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,16 +20,22 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: Make build
+      - name: Build
         run: make build
 
-      - name: Make clean
+      - name: Clean
         run: make clean
 
-      - name: Make debug
+      - name: Debug
         run: make debug
 
+      - name: Set up Python
+        use : actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install cpplint
+        run: pip install cpplint
+
       - name: Lint
-        run: |
-          pip3 install cpplint
-          make lint
+        run: make lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Debug
         run: make debug
 
+      - name: Test
+        run: make test
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         run: make debug
 
       - name: Set up Python
-        use : actions/setup-python@v2
+        uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install cpplint
-        run: pip install cpplint
+        run: pip3 install cpplint
 
       - name: Lint
         run: make lint

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-build/include_subdir,-legal/copyright,-whitespace/line_length,-readability/casting

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-build/include_subdir,-legal/copyright,-whitespace/line_length,-readability/casting
+filter=-build/include_subdir,-legal/copyright,-whitespace/line_length,-readability/casting,-runtime/int

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ lint:
 	@type cpplint
 	@cpplint *.h *.c
 
+test:
+	@echo TODO
+
 clean:
 	@rm -rf bin *.o
 
-.PHONY: build debug lint clean
+.PHONY: build debug lint test clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-CC   := gcc
-SRCS := command command_raw net cluster copy
-OBJS := $(addsuffix .o,$(SRCS))
+CC    := gcc
+SHELL := /bin/bash
+SRCS  := command command_raw net cluster copy
+OBJS  := $(addsuffix .o,$(SRCS))
 
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809
 CFLAGS += -Wall -Wextra -Wpedantic
@@ -52,7 +53,11 @@ bin/dcli: CPPFLAGS += -DDEBUG
 bin/dcli: client.o $(OBJS)
 	$(call link)
 
+lint:
+	@type cpplint
+	@cpplint *.h *.c
+
 clean:
 	@rm -rf bin *.o
 
-.PHONY: build debug clean
+.PHONY: build debug lint clean

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809
 CFLAGS += -Wall -Wextra -Wpedantic
 
 WORKER   ?= 8
-TIMEOUT  ?= 30
-PIPELINE ?= 100
+TIMEOUT  ?= 15
+PIPELINE ?= 20
 
 define link
 	@mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809
 CFLAGS += -Wall -Wextra -Wpedantic
 
 WORKER   ?= 8
-TIMEOUT  ?= 15
-PIPELINE ?= 20
+TIMEOUT  ?= 5
+PIPELINE ?= 10
 
 define link
 	@mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC   := gcc
-SRCS := command net cluster
+SRCS := command command_raw net cluster
 OBJS := $(addsuffix .o,$(SRCS))
 
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC   := gcc
-SRCS := command command_raw net cluster
+SRCS := command command_raw net cluster copy
 OBJS := $(addsuffix .o,$(SRCS))
 
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I need a copy tool.
 * AUTH
 * SSL
 * RESP3
+* Windows
 
 so on and so forth
 

--- a/client.c
+++ b/client.c
@@ -40,9 +40,9 @@ static char *trim(char *str) {
 
 int main(int argc, char **argv) {
   char buf[MAX_CMD_SIZE], *cmd;
+  int ret;
   Cluster cluster;
   Reply reply;
-  int ret;
 
   if (argc != 2) {
     fprintf(stderr, "Usage: bin/cli host:port\n");
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
   printClusterNodes(&cluster);
 
   while (1) {
-    printf("cli> ");
+    printf(">> ");
 
     if (fgets(buf, sizeof(buf), stdin) == NULL) {
       fprintf(stderr, "fgets(3)\n");

--- a/client.c
+++ b/client.c
@@ -28,12 +28,12 @@ static char *trim(char *str) {
   char *head;
 
   if (str == NULL) return str;
-  while (*str == ' ') ++str;
+  while (*str == '\n' || *str == '\r' || *str == ' ' || *str == '\t') ++str;
   head = str;
   while (*str != '\0') ++str;
-  --str;
-  while (*str == '\n' || *str == '\r' || *str == ' ') --str;
-  *(++str) = '\0';
+  if (head != str) --str;
+  while (*str == '\n' || *str == '\r' || *str == ' ' || *str == '\t') --str;
+  if (head != str) *(++str) = '\0';
 
   return head;
 }
@@ -61,6 +61,8 @@ int main(int argc, char **argv) {
     }
 
     cmd = trim(buf);
+    if (cmd[0] == '\0') continue;
+
     ret = execute(&cluster, cmd, &reply);
     if (ret == MY_ERR_CODE) {
       freeReply(&reply);

--- a/cluster.c
+++ b/cluster.c
@@ -173,3 +173,22 @@ int key2slot(const Cluster *cluster, const char *cmd) {
 
   return slot;
 }
+
+int countKeysInSlot(Conn *conn, int slot) {
+  char buf[MAX_CMD_SIZE], *line;
+  int ret;
+  Reply reply;
+
+  snprintf(buf, MAX_CMD_SIZE, "CLUSTER COUNTKEYSINSLOT %d", slot);
+  ret = command(conn, buf, &reply);
+  if (ret == MY_ERR_CODE) {
+    freeReply(&reply);
+    return ret;
+  }
+
+  line = LAST_LINE2(reply);
+  ret = line == NULL ? 0 : atoi(line);
+  freeReply(&reply);
+
+  return ret;
+}

--- a/cluster.c
+++ b/cluster.c
@@ -30,8 +30,8 @@ static int buildClusterState(const Reply *reply, Cluster *cluster) {
 
     first = atoi(reply->lines[i]);
     last = atoi(reply->lines[i+1]);
-    strcpy(cluster->nodes[cluster->i]->addr.host, reply->lines[i+2]);
-    strcpy(cluster->nodes[cluster->i]->addr.port, reply->lines[i+3]);
+    snprintf(cluster->nodes[cluster->i]->addr.host, MAX_HOST_SIZE, "%s", reply->lines[i+2]);
+    snprintf(cluster->nodes[cluster->i]->addr.port, MAX_PORT_SIZE, "%s", reply->lines[i+3]);
 
     for (j = first; j <= last; ++j) cluster->slots[j] = cluster->i;
     cluster->i++;
@@ -89,8 +89,8 @@ Cluster *copyClusterState(const Cluster *src) {
     dest->nodes[i] = (Conn *) malloc(sizeof(Conn));
     ASSERT_MALLOC(dest->nodes[i], "for new cluster connection on copy");
 
-    strcpy(dest->nodes[i]->addr.host, src->nodes[i]->addr.host);
-    strcpy(dest->nodes[i]->addr.port, src->nodes[i]->addr.port);
+    snprintf(dest->nodes[i]->addr.host, MAX_HOST_SIZE, "%s", src->nodes[i]->addr.host);
+    snprintf(dest->nodes[i]->addr.port, MAX_PORT_SIZE, "%s", src->nodes[i]->addr.port);
 
     if (createConnection(dest->nodes[i]) == MY_ERR_CODE) return NULL;
   }
@@ -148,10 +148,10 @@ int key2slot(const Cluster *cluster, const char *cmd) {
   line = LAST_LINE2(reply);
   if (line == NULL || strlen(line) == 0) {
     freeReply(&reply);
-    return ANY_NODE_OK; // FIXME: blank is a bug
+    return ANY_NODE_OK;  // FIXME: blank is a bug
   }
 
-  strcpy(kBuf, line);
+  snprintf(kBuf, MAX_KEY_SIZE, "%s", line);
   freeReply(&reply);
 
   snprintf(cBuf, MAX_CMD_SIZE, "CLUSTER KEYSLOT %s", kBuf);

--- a/cluster.c
+++ b/cluster.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include "./generic.h"
 #include "./cluster.h"
-#include "./net.h"
 #include "./command.h"
 
 #define DEFAULT_NODE_SIZE 8

--- a/cluster.c
+++ b/cluster.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include "./generic.h"
 #include "./cluster.h"
 #include "./net.h"
 #include "./command.h"

--- a/cluster.c
+++ b/cluster.c
@@ -129,6 +129,14 @@ void printClusterNodes(const Cluster *c) {
   }
 }
 
+static inline int isKeylessCommand(const char *cmd) {
+  while (*cmd != '\0') {
+    if (*cmd == ' ') return 0;
+    ++cmd;
+  }
+  return 1;
+}
+
 int key2slot(const Cluster *cluster, const char *cmd) {
   char cBuf[MAX_CMD_SIZE], kBuf[MAX_KEY_SIZE], *line;
   int slot, ret;
@@ -146,9 +154,9 @@ int key2slot(const Cluster *cluster, const char *cmd) {
   }
 
   line = LAST_LINE2(reply);
-  if (line == NULL || strlen(line) == 0) {
+  if (line == NULL || strlen(line) == 0) {  // FIXME: blank is a bug
     freeReply(&reply);
-    return ANY_NODE_OK;  // FIXME: blank is a bug
+    return ANY_NODE_OK;
   }
 
   snprintf(kBuf, MAX_KEY_SIZE, "%s", line);

--- a/cluster.c
+++ b/cluster.c
@@ -118,7 +118,7 @@ void printClusterSlots(const Cluster *c) {
 
   for (i = 0; i < CLUSTER_SLOT_SIZE; ++i) {
     conn = FIND_CONN(c, i);
-    fprintf(stdout, "%05d\t%s:%s\n", i, conn->addr.host, conn->addr.port);
+    printf("%05d\t%s:%s\n", i, conn->addr.host, conn->addr.port);
   }
 }
 

--- a/cluster.h
+++ b/cluster.h
@@ -19,4 +19,4 @@ void printClusterNodes(const Cluster *);
 int key2slot(const Cluster *cluster, const char *);
 int countKeysInSlot(Conn *, int);
 
-#endif // CLUSTER_H_
+#endif  // CLUSTER_H_

--- a/cluster.h
+++ b/cluster.h
@@ -1,8 +1,6 @@
 #ifndef CLUSTER_H_
 #define CLUSTER_H_
 
-#include "./generic.h"
-
 int fetchClusterState(const char *, Cluster *);
 Cluster *copyClusterState(const Cluster *);
 int freeClusterState(Cluster *);

--- a/cluster.h
+++ b/cluster.h
@@ -1,6 +1,16 @@
 #ifndef CLUSTER_H_
 #define CLUSTER_H_
 
+#include "./net.h"
+
+#define CLUSTER_SLOT_SIZE 16384
+#define ANY_NODE_OK -2
+
+#define FIND_CONN(c, i) (c->nodes[c->slots[i]])
+#define FIND_CONN2(c, i) (c.nodes[c.slots[i]])
+
+typedef struct { int size, i; Conn **nodes; int slots[CLUSTER_SLOT_SIZE]; } Cluster;
+
 int fetchClusterState(const char *, Cluster *);
 Cluster *copyClusterState(const Cluster *);
 int freeClusterState(Cluster *);

--- a/cluster.h
+++ b/cluster.h
@@ -9,5 +9,6 @@ int freeClusterState(Cluster *);
 void printClusterSlots(const Cluster *);
 void printClusterNodes(const Cluster *);
 int key2slot(const Cluster *cluster, const char *);
+int countKeysInSlot(Conn *, int);
 
 #endif // CLUSTER_H_

--- a/command.c
+++ b/command.c
@@ -182,15 +182,19 @@ int commandWithRawData(Conn *conn, const void *cmd, Reply *reply, int size) {
 
   ret = send(sock, cmd, size, 0);
   if (ret == -1) {
-    fprintf(stderr, "send(2): returns -1: %s:%s\n", conn->addr.host, conn->addr.port);
-    return MY_ERR_CODE;
+    perror("send(2)");
+    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
+    return reconnect(conn) == MY_OK_CODE ? commandWithRawData(conn, cmd, reply, size) : MY_ERR_CODE;
   }
 
   ret = recv(sock, buf, MAX_RECV_SIZE, 0);
   if (ret == -1) {
-    fprintf(stderr, "recv(2): returns -1: %s:%s\n", conn->addr.host, conn->addr.port);
+    perror("recv(2)");
+    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
     return MY_ERR_CODE;
   }
+
+  INIT_REPLY(reply);
 
   return MY_OK_CODE;
 }

--- a/command.c
+++ b/command.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include "./generic.h"
 #include "./command.h"
-#include "./net.h"
 
 static inline int copyReplyLineWithoutMeta(Reply *reply, const char *buf, int offset, ReplyType t) {
   int len, realLen;

--- a/command.c
+++ b/command.c
@@ -196,7 +196,7 @@ int commandWithRawData(Conn *conn, const void *cmd, Reply *reply, int size) {
 }
 
 void printReplyLines(const Reply *reply) {
-  int i;
+  int i, j;
 
   for (i = 0; i < reply->i; ++i) {
     switch (reply->types[i]) {
@@ -206,7 +206,8 @@ void printReplyLines(const Reply *reply) {
         fprintf(stdout, "%s\n",  reply->lines[i]);
         break;
       case RAW:
-        fprintf(stdout, "(binary)\n");
+        for (j = 0; j < reply->sizes[i]; ++j) printf("%02x ", ((unsigned char *) reply->lines[i])[j]);
+        printf("\n");
         break;
       case NIL:
         fprintf(stdout, "(null)\n");

--- a/command.c
+++ b/command.c
@@ -8,11 +8,12 @@
 #define INIT_REPLY(r) do {\
   r->size = DEFAULT_REPLY_LINES;\
   r->i = 0;\
-  r->err = 0;\
   r->lines = (char **) malloc(sizeof(char *) * r->size);\
   ASSERT_MALLOC(r->lines, "for init reply lines");\
   r->types = (ReplyType *) malloc(sizeof(ReplyType) * r->size);\
   ASSERT_MALLOC(r->types, "for init reply types");\
+  r->sizes = (int *) malloc(sizeof(int) * r->size);\
+  ASSERT_MALLOC(r->sizes, "for init reply sizes");\
 } while (0)
 
 #define EXPAND_REPLY_IF_NEEDED(r) do {\
@@ -25,6 +26,9 @@
     tmp = realloc(r->types, sizeof(ReplyType) * r->size);\
     ASSERT_REALLOC(tmp, "for reply types");\
     r->types = (ReplyType *) tmp;\
+    tmp = realloc(r->sizes, sizeof(int) * r->size);\
+    ASSERT_REALLOC(tmp, "for reply sizes");\
+    r->sizes = (int *) tmp;\
   }\
 } while (0)
 
@@ -40,24 +44,23 @@ static inline int copyReplyLineWithoutMeta(Reply *reply, const char *buf, int of
   strncpy(reply->lines[reply->i], buf + offset, len + 1); // terminator
   reply->lines[reply->i][len] = '\0';
   reply->types[reply->i] = t;
+  reply->sizes[reply->i] = realLen;
   reply->i++;
   return realLen;
 }
 
+static inline void addNullReply(Reply *reply) {
+  reply->lines[reply->i] = NULL;
+  reply->types[reply->i] = NIL;
+  reply->sizes[reply->i] = 0;
+  reply->i++;
+}
+
 static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
-  int i, size, readSize;
+  int i, ret, size, readSize;
   char *buf;
 
-  if (n == 1) {
-    size = strlen(cmd);
-    buf = (char *) malloc(sizeof(char) * (size + 3)); // \r \n \0
-    ASSERT_MALLOC(buf, "for writing command buffer");
-    snprintf(buf, size + 3, "%s\r\n", cmd);
-    size = fputs(buf, conn->fw);
-    free(buf);
-  } else {
-    size = fputs(cmd, conn->fw);
-  }
+  size = fputs(cmd, conn->fw);
   if (size == EOF) {
     fprintf(stderr, "fputs(3): %s to %s:%s\n", cmd, conn->addr.host, conn->addr.port);
     return MY_ERR_CODE;
@@ -68,20 +71,14 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
   }
 
   INIT_REPLY(reply);
-  for (i = n, size = DEFAULT_REPLY_SIZE; i > 0; --i) {
+  for (i = n, size = DEFAULT_REPLY_SIZE, ret = MY_OK_CODE; i > 0; --i) {
     EXPAND_REPLY_IF_NEEDED(reply);
     buf = (char *) malloc(sizeof(char) * (size + 3)); // \r \n \0
     ASSERT_MALLOC(buf, "for reading reply buffer");
     if (fgets(buf, size + 3, conn->fr) == NULL) { // \r \n \0
       free(buf);
       freeReply(reply);
-      if (n > 1) {
-        fprintf(stderr, "fgets(3): returns NULL when execute pipelined commands to %s:%s\n%s", conn->addr.host, conn->addr.port, cmd);
-        fprintf(stderr, "Reconnect to %s:%s for retrying the above commands\n", conn->addr.host, conn->addr.port);
-      } else {
-        fprintf(stderr, "fgets(3): returns NULL when execute `%s` to %s:%s\n", cmd, conn->addr.host, conn->addr.port);
-        fprintf(stderr, "Reconnect to %s:%s for retrying `%s`\n", conn->addr.host, conn->addr.port, cmd);
-      }
+      fprintf(stderr, "fgets(3): returns NULL, trying to reconnect to %s:%s\n", conn->addr.host, conn->addr.port);
       return reconnect(conn) == MY_OK_CODE ? executeCommand(conn, cmd, reply, n) : MY_ERR_CODE;
     }
     // @see https://redis.io/topics/protocol Redis Protocol specification
@@ -90,15 +87,20 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
         copyReplyLineWithoutMeta(reply, buf, 1, STRING);
         break;
       case '-':
-        copyReplyLineWithoutMeta(reply, buf, 1, STRING);
-        reply->err = 1;
+        copyReplyLineWithoutMeta(reply, buf, 1, ERR);
+        fprintf(stderr, "%s:%s says %s\n", conn->addr.host, conn->addr.port, LAST_LINE(reply));
+        ret = MY_ERR_CODE;
         break;
       case ':':
         copyReplyLineWithoutMeta(reply, buf, 1, INTEGER);
         break;
       case '$':
         size = atoi(buf + 1);
-        if (size > -1) ++i;
+        if (size >= 0) {
+          ++i;
+        } else if (size == -1) {
+          addNullReply(reply);
+        }
         break;
       case '*':
         i += atoi(buf + 1);
@@ -118,17 +120,20 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
     free(buf);
   }
 
-  if (n == 1 && reply->err) {
-    fprintf(stderr, "Tried `%s` to %s:%s\n", cmd, conn->addr.host, conn->addr.port);
-    fprintf(stderr, "%s\n", LAST_LINE(reply));
-    return MY_ERR_CODE;
-  }
-
-  return MY_OK_CODE;
+  return ret;
 }
 
 int command(Conn *conn, const char *cmd, Reply *reply) {
-  return executeCommand(conn, cmd, reply, 1);
+  char *buf;
+  int ret;
+
+  buf = (char *) malloc(sizeof(char) * MAX_CMD_SIZE);
+  ASSERT_MALLOC(buf, "for writing command buffer");
+  snprintf(buf, MAX_CMD_SIZE, "%s\r\n", cmd);
+  ret = executeCommand(conn, buf, reply, 1);
+  free(buf);
+
+  return ret;
 }
 
 
@@ -144,13 +149,17 @@ void freeReply(Reply *reply) {
   reply->lines = NULL;
   free(reply->types);
   reply->types = NULL;
-  reply->i = reply->size = reply->err = 0;
+  free(reply->sizes);
+  reply->sizes = NULL;
+  reply->i = reply->size = 0;
 }
 
 void printReplyLines(const Reply *reply) {
   int i;
 
-  for (i = 0; i < reply->i; ++i) fprintf(stdout, "%s\n", reply->lines[i]);
+  for (i = 0; i < reply->i; ++i) {
+    fprintf(stdout, "%s\n", reply->types[i] != NIL ? reply->lines[i] : "(null)");
+  }
 }
 
 int isKeylessCommand(const char *cmd) {

--- a/command.c
+++ b/command.c
@@ -42,6 +42,7 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
       fprintf(stderr, "fgets(3): returns NULL, trying to reconnect to %s:%s\n", conn->addr.host, conn->addr.port);
       return reconnect(conn) == MY_OK_CODE ? executeCommand(conn, cmd, reply, n) : MY_ERR_CODE;
     }
+
     // @see https://redis.io/topics/protocol Redis Protocol specification
     if (isBulkStr) {
       // bulk string
@@ -80,6 +81,8 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
           i += atoi(buf + 1);
           break;
         default:
+          // Not expected token, Skip last remained reply line
+          ++i;
           break;
       }
     }
@@ -134,12 +137,4 @@ void printReplyLines(const Reply *reply) {
         break;
     }
   }
-}
-
-int isKeylessCommand(const char *cmd) {
-  while (*cmd != '\0') {
-    if (*cmd == ' ') return 0;
-    ++cmd;
-  }
-  return 1;
 }

--- a/command.c
+++ b/command.c
@@ -8,10 +8,10 @@ static inline int copyReplyLineWithoutMeta(Reply *reply, const char *buf, int of
   len = realLen = strlen(buf);
   if (buf[len - 1] == '\n') --len;
   if (buf[len - 1] == '\r') --len;
-  len -= offset; // special chars
-  reply->lines[reply->i] = (char *) malloc(sizeof(char) * (len + 1)); // terminator
+  len -= offset;  // special chars
+  reply->lines[reply->i] = (char *) malloc(sizeof(char) * (len + 1));  // terminator
   ASSERT_MALLOC(reply->lines[reply->i], "for new reply line");
-  strncpy(reply->lines[reply->i], buf + offset, len + 1); // terminator
+  strncpy(reply->lines[reply->i], buf + offset, len + 1);  // terminator
   reply->lines[reply->i][len] = '\0';
   reply->types[reply->i] = t;
   reply->sizes[reply->i] = len;
@@ -36,9 +36,9 @@ static int executeCommand(Conn *conn, const char *cmd, Reply *reply, int n) {
   INIT_REPLY(reply);
   for (i = n, size = DEFAULT_REPLY_SIZE, ret = MY_OK_CODE, isBulkStr = 0; i > 0; --i) {
     EXPAND_REPLY_IF_NEEDED(reply);
-    buf = (char *) malloc(sizeof(char) * (size + 3)); // \r \n \0
+    buf = (char *) malloc(sizeof(char) * (size + 3));  // \r \n \0
     ASSERT_MALLOC(buf, "for reading reply buffer");
-    if (fgets(buf, size + 3, conn->fr) == NULL) { // \r \n \0
+    if (fgets(buf, size + 3, conn->fr) == NULL) {  // \r \n \0
       free(buf);
       freeReply(reply);
       fprintf(stderr, "fgets(3): returns NULL, trying to reconnect to %s:%s\n", conn->addr.host, conn->addr.port);

--- a/command.c
+++ b/command.c
@@ -126,14 +126,14 @@ void printReplyLines(const Reply *reply) {
       case STRING:
       case INTEGER:
       case ERR:
-        fprintf(stdout, "%s\n",  reply->lines[i]);
+        fprintf(stderr, "%s\n",  reply->lines[i]);
         break;
       case RAW:
         for (j = 0; j < reply->sizes[i]; ++j) printf("%02x ", ((unsigned char *) reply->lines[i])[j]);
         printf("\n");
         break;
       case NIL:
-        fprintf(stdout, "(null)\n");
+        printf("(null)\n");
         break;
       default:
         break;

--- a/command.c
+++ b/command.c
@@ -124,7 +124,7 @@ void printReplyLines(const Reply *reply) {
       case STRING:
       case INTEGER:
       case ERR:
-        fprintf(stderr, "%s\n",  reply->lines[i]);
+        printf("%s\n",  reply->lines[i]);
         break;
       case RAW:
         PRINT_BINARY(reply->lines[i], reply->sizes[i]);

--- a/command.c
+++ b/command.c
@@ -123,7 +123,7 @@ void freeReply(Reply *reply) {
 }
 
 void printReplyLines(const Reply *reply) {
-  int i, j;
+  int i;
 
   for (i = 0; i < reply->i; ++i) {
     switch (reply->types[i]) {
@@ -133,7 +133,7 @@ void printReplyLines(const Reply *reply) {
         fprintf(stderr, "%s\n",  reply->lines[i]);
         break;
       case RAW:
-        for (j = 0; j < reply->sizes[i]; ++j) printf("%02x ", ((unsigned char *) reply->lines[i])[j]);
+        PRINT_BINARY(reply->lines[i], reply->sizes[i]);
         printf("\n");
         break;
       case NIL:

--- a/command.h
+++ b/command.h
@@ -52,6 +52,5 @@ int command(Conn *, const char *, Reply *);
 int pipeline(Conn *, const char *, Reply *, int);
 void freeReply(Reply *);
 void printReplyLines(const Reply *);
-int isKeylessCommand(const char *);
 
 #endif  // COMMAND_H_

--- a/command.h
+++ b/command.h
@@ -3,7 +3,7 @@
 
 #include "./net.h"
 
-#define MAX_CMD_SIZE 4096
+#define MAX_CMD_SIZE (1 << 14)
 #define MAX_KEY_SIZE 256
 #define DEFAULT_REPLY_LINES 16
 #define DEFAULT_REPLY_SIZE 256

--- a/command.h
+++ b/command.h
@@ -1,8 +1,15 @@
 #ifndef COMMAND_H_
 #define COMMAND_H_
 
+#include "./net.h"
+
+#define MAX_CMD_SIZE 4096
+#define MAX_KEY_SIZE 256
 #define DEFAULT_REPLY_LINES 16
 #define DEFAULT_REPLY_SIZE 256
+
+#define LAST_LINE(r) (r->i > 0 ? r->lines[r->i - 1] : NULL)
+#define LAST_LINE2(r) (r.i > 0 ? r.lines[r.i - 1] : NULL)
 
 #define INIT_REPLY(r) do {\
   r->size = DEFAULT_REPLY_LINES;\
@@ -37,6 +44,9 @@
   reply->types[reply->i] = NIL;\
   reply->i++;\
 } while (0)
+
+typedef enum { STRING, INTEGER, RAW, ERR, NIL } ReplyType;
+typedef struct { int size, i, *sizes; char **lines; ReplyType *types; } Reply;
 
 int command(Conn *, const char *, Reply *);
 int pipeline(Conn *, const char *, Reply *, int);

--- a/command.h
+++ b/command.h
@@ -1,11 +1,45 @@
 #ifndef COMMAND_H_
 #define COMMAND_H_
 
-#include "./generic.h"
+#define DEFAULT_REPLY_LINES 16
+#define DEFAULT_REPLY_SIZE 256
+
+#define INIT_REPLY(r) do {\
+  r->size = DEFAULT_REPLY_LINES;\
+  r->i = 0;\
+  r->lines = (char **) malloc(sizeof(char *) * r->size);\
+  ASSERT_MALLOC(r->lines, "for init reply lines");\
+  r->types = (ReplyType *) malloc(sizeof(ReplyType) * r->size);\
+  ASSERT_MALLOC(r->types, "for init reply types");\
+  r->sizes = (int *) malloc(sizeof(int) * r->size);\
+  ASSERT_MALLOC(r->sizes, "for init reply sizes");\
+} while (0)
+
+#define EXPAND_REPLY_IF_NEEDED(r) do {\
+  if (r->i == r->size) {\
+    void *tmp;\
+    r->size *= 2;\
+    tmp = realloc(r->lines, sizeof(char *) * r->size);\
+    ASSERT_REALLOC(tmp, "for reply lines");\
+    r->lines = (char **) tmp;\
+    tmp = realloc(r->types, sizeof(ReplyType) * r->size);\
+    ASSERT_REALLOC(tmp, "for reply types");\
+    r->types = (ReplyType *) tmp;\
+    tmp = realloc(r->sizes, sizeof(int) * r->size);\
+    ASSERT_REALLOC(tmp, "for reply sizes");\
+    r->sizes = (int *) tmp;\
+  }\
+} while (0)
+
+#define ADD_NULL_REPLY(reply) do {\
+  reply->sizes[reply->i] = 0;\
+  reply->lines[reply->i] = NULL;\
+  reply->types[reply->i] = NIL;\
+  reply->i++;\
+} while (0)
 
 int command(Conn *, const char *, Reply *);
 int pipeline(Conn *, const char *, Reply *, int);
-int commandWithRawData(Conn *, const void *, Reply *, int);
 void freeReply(Reply *);
 void printReplyLines(const Reply *);
 int isKeylessCommand(const char *);

--- a/command.h
+++ b/command.h
@@ -4,7 +4,8 @@
 #include "./generic.h"
 
 int command(Conn *, const char *, Reply *);
-int pipeline(Conn *, const char *, Reply *, int n);
+int pipeline(Conn *, const char *, Reply *, int);
+int commandWithRawData(Conn *, const void *, Reply *, int);
 void freeReply(Reply *);
 void printReplyLines(const Reply *);
 int isKeylessCommand(const char *);

--- a/command.h
+++ b/command.h
@@ -54,4 +54,4 @@ void freeReply(Reply *);
 void printReplyLines(const Reply *);
 int isKeylessCommand(const char *);
 
-#endif // COMMAND_H_
+#endif  // COMMAND_H_

--- a/command.h
+++ b/command.h
@@ -15,11 +15,12 @@
   r->lines[r->i] = NULL;\
   r->types[r->i] = UNKNOWN;\
   r->sizes[r->i] = 0;\
+  r->nextIdxOfLastLine = 0;\
 } while (0)
 
 #define INIT_REPLY(r) do {\
   r->size = DEFAULT_REPLY_LINES;\
-  r->i = r->nextIdxOfLastLine = 0;\
+  r->i = 0;\
   r->lines = (char **) malloc(sizeof(char *) * r->size);\
   ASSERT_MALLOC(r->lines, "for init reply lines");\
   r->types = (ReplyType *) malloc(sizeof(ReplyType) * r->size);\
@@ -47,7 +48,7 @@
 
 #define ADVANCE_REPLY_LINE(r) do {\
   reply->i++;\
-  reply->nextIdxOfLastLine = 0;\
+  EXPAND_REPLY_IF_NEEDED(r);\
   INIT_REPLY_LINE(r);\
 } while (0)
 
@@ -58,7 +59,7 @@
   ADVANCE_REPLY_LINE(r);\
 } while (0)
 
-typedef enum { UNKNOWN, STRING, INTEGER, RAW, ERR, NIL } ReplyType;
+typedef enum { UNKNOWN, STRING, INTEGER, RAW, ERR, NIL, TMPBULKSTR, TMPARR } ReplyType;
 typedef struct { int size, i, nextIdxOfLastLine, *sizes; char **lines; ReplyType *types; } Reply;
 
 int command(Conn *, const char *, Reply *);

--- a/command_raw.c
+++ b/command_raw.c
@@ -13,7 +13,7 @@ static inline int copyReplyLineFromMultiLine(Reply *reply, const char *buf, int 
   ASSERT_MALLOC(reply->lines[reply->i], "for new reply line from multi lines");
   for (i = 0; buf[i] != '\r' && buf[i] != '\n'; ++i) reply->lines[reply->i][i] = buf[i];
   reply->lines[reply->i][i] = '\0';
-  for (; buf[i] == '\r' && buf[i] == '\n'; ++i) {};
+  for (; buf[i] == '\r' && buf[i] == '\n'; ++i) {}
   reply->types[reply->i] = t;
   reply->sizes[reply->i] = i;
   reply->i++;
@@ -53,9 +53,10 @@ static void parseRawReply(const char *buf, Reply *reply, int size) {
         i += copyReplyLineFromMultiLine(reply, &buf[i], DEFAULT_REPLY_SIZE, INTEGER);
         break;
       case '$':
-        for (j = 0, ++i; buf[i] != '\r'; ++j, ++i) tmp[j] = buf[i];
+        ++i;
+        for (j = 0; buf[i] != '\r'; ++j, ++i) tmp[j] = buf[i];
         tmp[j] = '\0';
-        ++i; // \n
+        ++i;  // \n
         n = atoi(tmp);
         if (n >= 0) {
           i += copyReplyLinesFromMultiLine(reply, &buf[i + 1], n);
@@ -64,9 +65,9 @@ static void parseRawReply(const char *buf, Reply *reply, int size) {
         }
         break;
       case '*':
-        // TODO: impl
+        // TODO(me): impl
         while (buf[i] != '\r') ++i;
-        ++i; // \n
+        ++i;  // \n
         break;
       default:
         // not expected token

--- a/command_raw.c
+++ b/command_raw.c
@@ -86,14 +86,16 @@ int commandWithRawData(Conn *conn, const void *cmd, Reply *reply, int size) {
   ret = send(sock, cmd, size, 0);
   if (ret == -1) {
     perror("send(2)");
-    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
     return reconnect(conn) == MY_OK_CODE ? commandWithRawData(conn, cmd, reply, size) : MY_ERR_CODE;
   }
 
   ret = recv(sock, buf, MAX_RECV_SIZE, 0);
   if (ret == -1) {
     perror("recv(2)");
-    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
+    return MY_ERR_CODE;
+  }
+  if (ret == 0) {
+    fprintf(stderr, "recv(2): returns 0: %s:%s\n", conn->addr.host, conn->addr.port);
     return MY_ERR_CODE;
   }
 

--- a/command_raw.c
+++ b/command_raw.c
@@ -1,0 +1,103 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include "./generic.h"
+#include "./command.h"
+#include "./command_raw.h"
+#include "./net.h"
+
+#define MAX_RECV_SIZE (1 << 16)
+
+static inline int copyReplyLineFromMultiLine(Reply *reply, const char *buf, int size, ReplyType t) {
+  int i;
+
+  reply->lines[reply->i] = (char *) malloc(sizeof(char) * size);
+  ASSERT_MALLOC(reply->lines[reply->i], "for new reply line from multi lines");
+  for (i = 0; buf[i] != '\r' && buf[i] != '\n'; ++i) reply->lines[reply->i][i] = buf[i];
+  reply->lines[reply->i][i] = '\0';
+  for (; buf[i] == '\r' && buf[i] == '\n'; ++i) {};
+  reply->types[reply->i] = t;
+  reply->sizes[reply->i] = i;
+  reply->i++;
+  return i;
+}
+
+static inline int copyReplyLinesFromMultiLine(Reply *reply, const char *buf, int size) {
+  int i;
+
+  reply->sizes[reply->i] = size;
+  reply->types[reply->i] = RAW;
+  reply->lines[reply->i] = (char *) malloc(sizeof(char) * (size + 1));
+  ASSERT_MALLOC(reply->lines[reply->i], "for new reply lines from multi lines");
+  for (i = 0; i < size; ++i) reply->lines[reply->i][i] = buf[i];
+  reply->i++;
+  return size;
+}
+
+static void parseRawReply(const char *buf, Reply *reply, int size) {
+  int i, j, n;
+  char tmp[DEFAULT_REPLY_SIZE];
+
+  INIT_REPLY(reply);
+  for (i = 0; i < size; ++i) {
+    EXPAND_REPLY_IF_NEEDED(reply);
+    switch (buf[i]) {
+      case '+':
+        ++i;
+        i += copyReplyLineFromMultiLine(reply, &buf[i], DEFAULT_REPLY_SIZE, STRING);
+        break;
+      case '-':
+        ++i;
+        i += copyReplyLineFromMultiLine(reply, &buf[i], DEFAULT_REPLY_SIZE, ERR);
+        break;
+      case ':':
+        ++i;
+        i += copyReplyLineFromMultiLine(reply, &buf[i], DEFAULT_REPLY_SIZE, INTEGER);
+        break;
+      case '$':
+        for (j = 0, ++i; buf[i] != '\r'; ++j, ++i) tmp[j] = buf[i];
+        tmp[j] = '\0';
+        ++i; // \n
+        n = atoi(tmp);
+        if (n >= 0) {
+          i += copyReplyLinesFromMultiLine(reply, &buf[i + 1], n);
+        } else if (n == -1) {
+          ADD_NULL_REPLY(reply);
+        }
+        break;
+      case '*':
+        // TODO: impl
+        while (buf[i] != '\r') ++i;
+        ++i; // \n
+        break;
+      default:
+        // not expected token
+        break;
+    }
+  }
+}
+
+int commandWithRawData(Conn *conn, const void *cmd, Reply *reply, int size) {
+  int sock, ret;
+  char buf[MAX_RECV_SIZE];
+
+  fflush(conn->fw);
+  sock = fileno(conn->fw);
+
+  ret = send(sock, cmd, size, 0);
+  if (ret == -1) {
+    perror("send(2)");
+    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
+    return reconnect(conn) == MY_OK_CODE ? commandWithRawData(conn, cmd, reply, size) : MY_ERR_CODE;
+  }
+
+  ret = recv(sock, buf, MAX_RECV_SIZE, 0);
+  if (ret == -1) {
+    perror("recv(2)");
+    fprintf(stderr, "%s:%s\n", conn->addr.host, conn->addr.port);
+    return MY_ERR_CODE;
+  }
+
+  parseRawReply(buf, reply, ret);
+
+  return MY_OK_CODE;
+}

--- a/command_raw.c
+++ b/command_raw.c
@@ -103,6 +103,7 @@ static inline int parseBulkStringAsBinary(Reply *reply, const char *buf, int siz
   }
   if (reply->nextIdxOfLastLine < reply->sizes[reply->i]) return NEED_MORE_REPLY;
   ADVANCE_REPLY_LINE(reply);
+  while (buf[i] == '\r' || buf[i] == '\n') ++i;
   return i;
 }
 

--- a/command_raw.c
+++ b/command_raw.c
@@ -159,6 +159,7 @@ static int parseRawReply(const char *buf, int size, Reply *reply) {
           reply->types[reply->i] = TMPARR;
           break;
         default:
+          ASSERT_REPLY_PARSE(0, "not expected token");
           break;
       }
     } else if (reply->types[reply->i] == RAW) {

--- a/command_raw.c
+++ b/command_raw.c
@@ -3,7 +3,6 @@
 #include "./generic.h"
 #include "./command.h"
 #include "./command_raw.h"
-#include "./net.h"
 
 #define MAX_RECV_SIZE (1 << 16)
 

--- a/command_raw.h
+++ b/command_raw.h
@@ -5,4 +5,4 @@
 
 int commandWithRawData(Conn *, const void *, Reply *, int);
 
-#endif // COMMAND_RAW_H_
+#endif  // COMMAND_RAW_H_

--- a/command_raw.h
+++ b/command_raw.h
@@ -1,6 +1,8 @@
 #ifndef COMMAND_RAW_H_
 #define COMMAND_RAW_H_
 
+#include "./net.h"
+
 int commandWithRawData(Conn *, const void *, Reply *, int);
 
 #endif // COMMAND_RAW_H_

--- a/command_raw.h
+++ b/command_raw.h
@@ -4,7 +4,6 @@
 #include "./net.h"
 
 int commandWithRawData(Conn *, const void *, Reply *, int);
-int tryToReadFromSocket(Conn *, void *);
-int tryToWriteToSocket(Conn *, const void *, int);
+int readRemainedReplyLines(Conn *, Reply *);
 
 #endif  // COMMAND_RAW_H_

--- a/command_raw.h
+++ b/command_raw.h
@@ -4,5 +4,7 @@
 #include "./net.h"
 
 int commandWithRawData(Conn *, const void *, Reply *, int);
+int tryToReadFromSocket(Conn *, void *);
+int tryToWriteToSocket(Conn *, const void *, int);
 
 #endif  // COMMAND_RAW_H_

--- a/command_raw.h
+++ b/command_raw.h
@@ -1,0 +1,6 @@
+#ifndef COMMAND_RAW_H_
+#define COMMAND_RAW_H_
+
+int commandWithRawData(Conn *, const void *, Reply *, int);
+
+#endif // COMMAND_RAW_H_

--- a/copy.c
+++ b/copy.c
@@ -56,7 +56,7 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
   int i;
 
   if (keyPayloads->i % 2 > 0) {
-    fprintf(stderr, "RESTORE: Keys and payloads were mismatched.");
+    fprintf(stderr, "RESTORE: Keys and payloads were mismatched\n");
     result->failed += keyPayloads->i;
     return;
   }

--- a/copy.c
+++ b/copy.c
@@ -38,7 +38,7 @@ static inline void appendRestoreCmd(Pipeline *pip, const char *key, int keySize,
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$7\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "RESTORE\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$%d\r\n", keySize);
-  pip->i += snprintf(&pip->buf[pip->i], keySize, "%s", key);
+  for (i = 0; i < keySize; ++i) pip->buf[pip->i++] = key[i];
   pip->buf[pip->i++] = '\r';
   pip->buf[pip->i++] = '\n';
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$1\r\n");

--- a/copy.c
+++ b/copy.c
@@ -73,7 +73,7 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
     if (pip.cnt % PIPELINING_SIZE > 0 && i + 2 < keyPayloads->i) continue;
 
     commandWithRawData(c, pip.buf, &reply, pip.i);
-    ASSERT_RESTORE_DATA((reply.i == pip.cnt), "lack or too much reply");
+    ASSERT_RESTORE_DATA((reply.i == pip.cnt), "lack or too much reply lines");
     countRestoreResult(&reply, result);
 
     pip.cnt = pip.i = 0;

--- a/copy.c
+++ b/copy.c
@@ -62,6 +62,11 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
   }
 
   for (i = pip.cnt = pip.i = 0; i < keyPayloads->i; i += 2) {
+    if (keyPayloads->types[i+1] != RAW) {
+      result->skipped++;
+      continue;
+    }
+
     appendRestoreCmd(&pip, keyPayloads->lines[i], keyPayloads->sizes[i], keyPayloads->lines[i+1], keyPayloads->sizes[i+1]);
     if (pip.cnt % PIPELINING_SIZE > 0 && i + 2 < keyPayloads->i) continue;
 

--- a/copy.c
+++ b/copy.c
@@ -72,7 +72,7 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
     appendRestoreCmd(&pip, keyPayloads->lines[i], keyPayloads->sizes[i], keyPayloads->lines[i+1], keyPayloads->sizes[i+1]);
     if (pip.cnt % PIPELINING_SIZE > 0 && i + 2 < keyPayloads->i) continue;
 
-    pip.buf[pip.i] = '\0';
+    pip.buf[pip.i++] = '\0';
     commandWithRawData(c, pip.buf, &reply, pip.i);
     countRestoreResult(&reply, result, pip.cnt);
     pip.cnt = pip.i = 0;

--- a/copy.c
+++ b/copy.c
@@ -64,10 +64,12 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
   int i;
 
   for (i = pip.cnt = pip.i = 0; i < keyPayloads->i; i += 2) {
+    ASSERT_RESTORE_DATA((keyPayloads->types[i] == RAW), "must be a key");
     if (keyPayloads->types[i+1] == NIL) {
       result->skipped++;
       continue;
     }
+    ASSERT_RESTORE_DATA((keyPayloads->types[i+1] == RAW), "must be a payload");
 
     appendRestoreCmd(&pip, keyPayloads->lines[i], keyPayloads->sizes[i], keyPayloads->lines[i+1], keyPayloads->sizes[i+1]);
     if (pip.cnt % PIPELINING_SIZE > 0 && i + 2 < keyPayloads->i) continue;
@@ -100,6 +102,7 @@ static void fetchAndTransferKeys(Conn *src, Conn *dest, const Reply *keys, Migra
       ASSERT_RESTORE_DATA((reply.i == pip.cnt * 2), "key and payload pairs are wrong");
       transferKeys(dest, &reply, result);
     }
+
     pip.cnt = pip.i = 0;
     freeReply(&reply);
   }

--- a/copy.c
+++ b/copy.c
@@ -42,7 +42,7 @@ static inline void appendRestoreCmd(Pipeline *pip, const char *key, int keySize,
   pip->buf[pip->i++] = '\r';
   pip->buf[pip->i++] = '\n';
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$1\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], chunkSize, "0\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], chunkSize, "%d\r\n", 0);  // TTL msec
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$%d\r\n", payloadSize);
   for (i = 0; i < payloadSize; ++i) pip->buf[pip->i++] = payload[i];
   pip->buf[pip->i++] = '\r';

--- a/copy.c
+++ b/copy.c
@@ -22,7 +22,7 @@ static inline void countRestoreResult(const Reply *reply, MigrationResult *resul
         result->failed++;
         break;
       default:
-        result->skipped++;  // TODO(me): legit?
+        result->skipped++;  // FIXME(me): legit?
         break;
     }
   }
@@ -72,7 +72,6 @@ static void transferKeys(Conn *c, const Reply *keyPayloads, MigrationResult *res
     appendRestoreCmd(&pip, keyPayloads->lines[i], keyPayloads->sizes[i], keyPayloads->lines[i+1], keyPayloads->sizes[i+1]);
     if (pip.cnt % PIPELINING_SIZE > 0 && i + 2 < keyPayloads->i) continue;
 
-    pip.buf[pip.i++] = '\0';
     commandWithRawData(c, pip.buf, &reply, pip.i);
     countRestoreResult(&reply, result, pip.cnt);
     pip.cnt = pip.i = 0;
@@ -90,7 +89,6 @@ static void dumpAndRestoreKeys(Conn *src, Conn *dest, const Reply *keys, Migrati
     pip.cnt++;
     if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
 
-    pip.buf[pip.i] = '\0';
     ret = commandWithRawData(src, pip.buf, &reply, pip.i);
     if (ret == MY_ERR_CODE) {
       result->failed += pip.cnt;

--- a/copy.c
+++ b/copy.c
@@ -31,18 +31,20 @@ static inline void countRestoreResult(const Reply *reply, MigrationResult *resul
 }
 
 static inline void appendRestoreCmd(Pipeline *pip, const char *key, int keySize, const char *payload, int payloadSize) {
-  int j, chunkSize;
+  int i, chunkSize;
 
   chunkSize = 12;
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "*5\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$7\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "RESTORE\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$%d\r\n", keySize);
-  pip->i += snprintf(&pip->buf[pip->i], keySize + 3, "%s\r\n", key);
+  pip->i += snprintf(&pip->buf[pip->i], keySize, "%s", key);
+  pip->buf[pip->i++] = '\r';
+  pip->buf[pip->i++] = '\n';
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$1\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "0\r\n");
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$%d\r\n", payloadSize);
-  for (j = 0; j < payloadSize; ++j) pip->buf[pip->i++] = payload[j];
+  for (i = 0; i < payloadSize; ++i) pip->buf[pip->i++] = payload[i];
   pip->buf[pip->i++] = '\r';
   pip->buf[pip->i++] = '\n';
   pip->i += snprintf(&pip->buf[pip->i], chunkSize, "$7\r\n");

--- a/copy.c
+++ b/copy.c
@@ -1,0 +1,128 @@
+#include "./generic.h"
+#include "./command.h"
+#include "./command_raw.h"
+#include "./copy.h"
+
+#ifndef PIPELINING_SIZE
+#define PIPELINING_SIZE 10
+#endif // PIPELINING_SIZE
+
+typedef struct { char buf[MAX_CMD_SIZE * PIPELINING_SIZE]; int i, cnt; } Pipeline;
+
+static inline void countRestoreResult(const Reply *reply, MigrationResult *result, int expected) {
+  int i;
+
+  for (i = 0; i < reply->i; ++i) {
+    switch (reply->types[i]) {
+      case STRING:
+        result->copied++;
+        break;
+      case ERR:
+        fprintf(stderr, "%s\n", reply->lines[i]);
+        result->failed++;
+        break;
+      default:
+        result->failed++;
+        break;
+    }
+  }
+
+  if (reply->i < expected) result->failed += expected - reply->i;
+}
+
+static inline void appendRestoreCmd(Pipeline *pip, const char *key, int keySize, const char *payload, int payloadSize) {
+  int j;
+
+  pip->i += snprintf(&pip->buf[pip->i], 12, "*5\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$7\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "RESTORE\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$%d\r\n", keySize);
+  pip->i += snprintf(&pip->buf[pip->i], keySize + 3, "%s\r\n", key);
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$1\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "0\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$%d\r\n", payloadSize);
+  for (j = 0; j < payloadSize; ++j) pip->buf[pip->i++] = payload[j];
+  pip->buf[pip->i++] = '\r';
+  pip->buf[pip->i++] = '\n';
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$7\r\n");
+  pip->i += snprintf(&pip->buf[pip->i], 12, "REPLACE\r\n");
+  pip->cnt++;
+}
+
+static inline void sendResotreCmd(Conn *c, Pipeline *pip, Reply *reply, MigrationResult *result) {
+  pip->buf[pip->i] = '\0';
+  commandWithRawData(c, pip->buf, reply, pip->i);
+  countRestoreResult(reply, result, pip->cnt);
+  pip->cnt = pip->i = 0;
+}
+
+static void transferKeys(Conn *c, const Reply *keys, int first, int size, const Reply *values, MigrationResult *result) {
+  Pipeline pip;
+  Reply reply;
+  int i;
+
+  for (i = pip.cnt = pip.i = 0; i < size; ++i) {
+    if (values->types[i] == NIL) {
+      result->skipped++;
+      continue;
+    }
+
+    appendRestoreCmd(&pip, keys->lines[first+i], keys->sizes[first+i], values->lines[i], values->sizes[i]);
+    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
+
+    sendResotreCmd(c, &pip, &reply, result);
+    freeReply(&reply);
+  }
+}
+
+static void copyKeys(Conn *src, Conn *dest, const Reply *keys, MigrationResult *result) {
+  Pipeline pip;
+  Reply reply;
+  int i, ret, first;
+
+  for (i = first = pip.i = pip.cnt = 0; i < keys->i; ++i) {
+    pip.i += snprintf(&pip.buf[pip.i], MAX_KEY_SIZE * 2, "DUMP %s\r\n", keys->lines[i]);
+    pip.cnt++;
+    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
+
+    pip.buf[pip.i] = '\0';
+    ret = commandWithRawData(src, pip.buf, &reply, pip.i);
+    if (ret == MY_ERR_CODE) {
+      result->failed += pip.cnt;
+    } else {
+      if (pip.cnt != reply.i) {
+        // fprintf(stderr, "%s\n", pip.buf);
+        // printReplyLines(&reply);
+        fprintf(stderr, "RESTORE: keys and dump values are mismatched\n");
+        exit(1);
+      }
+      transferKeys(dest, keys, first, pip.cnt, &reply, result);
+    }
+    pip.cnt = pip.i = 0;
+    first = i + 1;
+    freeReply(&reply);
+  }
+}
+
+int migrateKeys(const Cluster *src, const Cluster *dest, int slot, int dryRun, MigrationResult *result) {
+  char buf[MAX_CMD_SIZE];
+  int ret;
+  Reply reply;
+
+  ret = countKeysInSlot(FIND_CONN(src, slot), slot);
+  if (ret == MY_ERR_CODE) return ret;
+  if (ret == 0) return MY_OK_CODE;
+  result->found += ret;
+  if (dryRun) return MY_OK_CODE;
+
+  snprintf(buf, MAX_CMD_SIZE, "CLUSTER GETKEYSINSLOT %d %d", slot, ret);
+  ret = command(FIND_CONN(src, slot), buf, &reply);
+  if (ret == MY_ERR_CODE) {
+    freeReply(&reply);
+    return ret;
+  }
+  copyKeys(FIND_CONN(src, slot), FIND_CONN(dest, slot), &reply, result);
+  freeReply(&reply);
+
+  return MY_OK_CODE;
+}

--- a/copy.h
+++ b/copy.h
@@ -1,10 +1,10 @@
 #ifndef COPY_H_
 #define COPY_H_
 
-#include "./cluster.h"
+#include "./net.h"
 
 typedef struct { int copied, skipped, failed, found; } MigrationResult;
 
-int copyKeys(const Cluster *, const Cluster *, int, int, MigrationResult *);
+int copyKeys(Conn *, Conn *, int, MigrationResult *, int);
 
 #endif  // COPY_H_

--- a/copy.h
+++ b/copy.h
@@ -1,0 +1,10 @@
+#ifndef COPY_H_
+#define COPY_H_
+
+#include "./cluster.h"
+
+typedef struct { int copied, skipped, failed, found; } MigrationResult;
+
+int migrateKeys(const Cluster *, const Cluster *, int, int, MigrationResult *);
+
+#endif // COPY_H_

--- a/copy.h
+++ b/copy.h
@@ -7,4 +7,4 @@ typedef struct { int copied, skipped, failed, found; } MigrationResult;
 
 int migrateKeys(const Cluster *, const Cluster *, int, int, MigrationResult *);
 
-#endif // COPY_H_
+#endif  // COPY_H_

--- a/copy.h
+++ b/copy.h
@@ -5,6 +5,6 @@
 
 typedef struct { int copied, skipped, failed, found; } MigrationResult;
 
-int migrateKeys(const Cluster *, const Cluster *, int, int, MigrationResult *);
+int copyKeys(const Cluster *, const Cluster *, int, int, MigrationResult *);
 
 #endif  // COPY_H_

--- a/generic.h
+++ b/generic.h
@@ -40,6 +40,6 @@ typedef struct { char host[MAX_HOST_SIZE], port[MAX_PORT_SIZE]; } HostPort;
 typedef struct { FILE *fw, *fr; HostPort addr; } Conn;
 typedef struct { int size, i; Conn **nodes; int slots[CLUSTER_SLOT_SIZE]; } Cluster;
 typedef enum { STRING, INTEGER, RAW, ERR, NIL } ReplyType;
-typedef struct { int size, i, err, *sizes; char **lines; ReplyType *types; } Reply;
+typedef struct { int size, i, *sizes; char **lines; ReplyType *types; } Reply;
 
 #endif // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -39,7 +39,7 @@
 typedef struct { char host[MAX_HOST_SIZE], port[MAX_PORT_SIZE]; } HostPort;
 typedef struct { FILE *fw, *fr; HostPort addr; } Conn;
 typedef struct { int size, i; Conn **nodes; int slots[CLUSTER_SLOT_SIZE]; } Cluster;
-typedef enum { STRING, INTEGER, ERR, NIL } ReplyType;
+typedef enum { STRING, INTEGER, RAW, ERR, NIL } ReplyType;
 typedef struct { int size, i, err, *sizes; char **lines; ReplyType *types; } Reply;
 
 #endif // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -6,12 +6,6 @@
 
 #define MY_OK_CODE 0
 #define MY_ERR_CODE -1
-#define ANY_NODE_OK -2
-#define MAX_HOST_SIZE 256
-#define MAX_PORT_SIZE 8
-#define MAX_CMD_SIZE 4096
-#define MAX_KEY_SIZE 256
-#define CLUSTER_SLOT_SIZE 16384
 
 #define ASSERT(ret) do {\
   if (ret == MY_ERR_CODE) exit(1);\
@@ -30,16 +24,5 @@
     exit(1);\
   }\
 } while (0)
-
-#define LAST_LINE(r) (r->i > 0 ? r->lines[r->i - 1] : NULL)
-#define LAST_LINE2(r) (r.i > 0 ? r.lines[r.i - 1] : NULL)
-#define FIND_CONN(c, i) (c->nodes[c->slots[i]])
-#define FIND_CONN2(c, i) (c.nodes[c.slots[i]])
-
-typedef struct { char host[MAX_HOST_SIZE], port[MAX_PORT_SIZE]; } HostPort;
-typedef struct { FILE *fw, *fr; HostPort addr; } Conn;
-typedef struct { int size, i; Conn **nodes; int slots[CLUSTER_SLOT_SIZE]; } Cluster;
-typedef enum { STRING, INTEGER, RAW, ERR, NIL } ReplyType;
-typedef struct { int size, i, *sizes; char **lines; ReplyType *types; } Reply;
 
 #endif // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -32,4 +32,15 @@
   }\
 } while (0)
 
+#define PRINT_MIXED_BINARY(line, size) do {\
+  int i;\
+  for (i = 0; i < size; ++i) {\
+    if ((' ' <= line[i] && line[i] <= '~') || line[i] == '\r' || line[i] == '\n') {\
+      printf("%c", line[i]);\
+    } else {\
+      printf("%02x", ((unsigned char *) line)[i]);\
+    }\
+  }\
+} while (0)
+
 #endif  // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -8,37 +8,37 @@
 #define MY_ERR_CODE -1
 
 #define ASSERT(ret) do {\
-  if (ret == MY_ERR_CODE) exit(1);\
+  if ((ret) == MY_ERR_CODE) exit(1);\
 } while (0)
 
 #define ASSERT_MALLOC(p, msg) do {\
-  if (p == NULL) {\
-    fprintf(stderr, "malloc(3): %s\n", msg);\
+  if ((p) == NULL) {\
+    fprintf(stderr, "malloc(3): %s\n", (msg));\
     exit(1);\
   }\
 } while (0)
 
 #define ASSERT_REALLOC(p, msg) do {\
-  if (p == NULL) {\
-    fprintf(stderr, "realloc(3): %s\n", msg);\
+  if ((p) == NULL) {\
+    fprintf(stderr, "realloc(3): %s\n", (msg));\
     exit(1);\
   }\
 } while (0)
 
 #define PRINT_BINARY(line, size) do {\
   int i;\
-  for (i = 0; i < size; ++i) {\
+  for (i = 0; i < (size); ++i) {\
     printf("%02x ", ((unsigned char *) line)[i]);\
   }\
 } while (0)
 
-#define PRINT_MIXED_BINARY(line, size) do {\
+#define PRINT_MIXED_BINARY(buf, size) do {\
   int i;\
-  for (i = 0; i < size; ++i) {\
-    if ((' ' <= line[i] && line[i] <= '~') || line[i] == '\r' || line[i] == '\n') {\
-      printf("%c", line[i]);\
+  for (i = 0; i < (size); ++i) {\
+    if ((' ' <= buf[i] && buf[i] <= '~') || buf[i] == '\r' || buf[i] == '\n') {\
+      printf("%c", buf[i]);\
     } else {\
-      printf("%02x", ((unsigned char *) line)[i]);\
+      printf("%02x", ((unsigned char *) buf)[i]);\
     }\
   }\
 } while (0)

--- a/generic.h
+++ b/generic.h
@@ -39,7 +39,7 @@
 typedef struct { char host[MAX_HOST_SIZE], port[MAX_PORT_SIZE]; } HostPort;
 typedef struct { FILE *fw, *fr; HostPort addr; } Conn;
 typedef struct { int size, i; Conn **nodes; int slots[CLUSTER_SLOT_SIZE]; } Cluster;
-typedef enum { STRING, INTEGER } ReplyType;
-typedef struct { int size, i, err; char **lines; ReplyType *types; } Reply;
+typedef enum { STRING, INTEGER, ERR, NIL } ReplyType;
+typedef struct { int size, i, err, *sizes; char **lines; ReplyType *types; } Reply;
 
 #endif // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -25,4 +25,11 @@
   }\
 } while (0)
 
+#define PRINT_BINARY(line, size) do {\
+  int i;\
+  for (i = 0; i < size; ++i) {\
+    printf("%02x ", ((unsigned char *) line)[i]);\
+  }\
+} while (0)
+
 #endif  // GENERIC_H_

--- a/generic.h
+++ b/generic.h
@@ -25,4 +25,4 @@
   }\
 } while (0)
 
-#endif // GENERIC_H_
+#endif  // GENERIC_H_

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ static int migrateKeysPerSlot(const Cluster *src, const Cluster *dest, int dryRu
   MigrationResult sum, results[MAX_CONCURRENCY];
 
   if (CLUSTER_SLOT_SIZE % MAX_CONCURRENCY > 0) {
-    fprintf(stderr, "MAX_CONCURRENCY must be %d's divisor: %d given", CLUSTER_SLOT_SIZE, MAX_CONCURRENCY);
+    fprintf(stderr, "MAX_CONCURRENCY must be %d's divisor: %d given\n", CLUSTER_SLOT_SIZE, MAX_CONCURRENCY);
     return MY_ERR_CODE;
   }
 
@@ -56,7 +56,7 @@ static int migrateKeysPerSlot(const Cluster *src, const Cluster *dest, int dryRu
 
     ret = pthread_create(&workers[i], NULL, workOnATask, &args[i]);
     if (ret != 0) {
-      fprintf(stderr, "pthread_create(3): Could not create a worker");
+      fprintf(stderr, "pthread_create(3): Could not create a worker\n");
       return MY_ERR_CODE;
     }
   }
@@ -64,7 +64,7 @@ static int migrateKeysPerSlot(const Cluster *src, const Cluster *dest, int dryRu
   for (i = 0; i < MAX_CONCURRENCY; ++i) {
     ret = pthread_join(workers[i], &tmp);
     if (ret != 0) {
-      fprintf(stderr, "pthread_join(3): Could not join with a thread");
+      fprintf(stderr, "pthread_join(3): Could not join with a thread\n");
       return MY_ERR_CODE;
     }
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
   sa.sa_flags = 0;
   sa.sa_handler = SIG_IGN;
   if (sigaction(SIGPIPE, &sa, NULL) < 0) {
-    fprintf(stderr, "sigaction(2): SIGPIPE failed");
+    fprintf(stderr, "sigaction(2): SIGPIPE failed\n");
     exit(1);
   }
 

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ static void *workOnATask(void *args) {
   printf("%02d: %lu <%lu>: %05d - %05d\n",
       p->i, (uint64_t) getpid(), (uint64_t) pthread_self(), p->firstSlot, p->lastSlot);
   p->result->found = p->result->copied = p->result->skipped = p->result->failed = 0;
-  for (i = p->firstSlot; i <= p->lastSlot; ++i) migrateKeys(p->src, p->dest, i, p->dryRun, p->result);
+  for (i = p->firstSlot; i <= p->lastSlot; ++i) copyKeys(p->src, p->dest, i, p->dryRun, p->result);
   pthread_exit((void *) p->result);
 }
 

--- a/main.c
+++ b/main.c
@@ -35,6 +35,10 @@ static inline void countRestoreResult(const Reply *reply, MigrationResult *resul
       case STRING:
         result->copied++;
         break;
+      case ERR:
+        fprintf(stderr, "%s\n", reply->lines[i]);
+        result->failed++;
+        break;
       default:
         result->failed++;
         break;
@@ -56,7 +60,9 @@ static inline void appendRestoreCmd(Pipeline *pip, const Reply *keys, const Repl
   pip->i += snprintf(&pip->buf[pip->i], 12, "0\r\n");
   pip->i += snprintf(&pip->buf[pip->i], 12, "$%d\r\n", values->sizes[i]);
   for (j = 0; j < values->sizes[i]; ++j) pip->buf[pip->i++] = values->lines[i][j];
-  pip->i += snprintf(&pip->buf[pip->i], 12, "\n$7\r\n");
+  pip->buf[pip->i++] = '\r';
+  pip->buf[pip->i++] = '\n';
+  pip->i += snprintf(&pip->buf[pip->i], 12, "$7\r\n");
   pip->i += snprintf(&pip->buf[pip->i], 12, "REPLACE\r\n");
   pip->cnt++;
 }

--- a/main.c
+++ b/main.c
@@ -2,142 +2,16 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <signal.h>
-#include <string.h>
 #include "./generic.h"
 #include "./net.h"
-#include "./command.h"
-#include "./command_raw.h"
 #include "./cluster.h"
+#include "./copy.h"
 
 #ifndef MAX_CONCURRENCY
 #define MAX_CONCURRENCY 4
 #endif // MAX_CONCURRENCY
 
-#ifndef PIPELINING_SIZE
-#define PIPELINING_SIZE 10
-#endif // PIPELINING_SIZE
-
-typedef struct { int copied, skipped, failed, found; } MigrationResult;
 typedef struct { Cluster *src, *dest; int i, firstSlot, lastSlot, dryRun; MigrationResult *result; } WorkerArgs;
-typedef struct { char buf[MAX_CMD_SIZE * PIPELINING_SIZE]; int i, cnt; } Pipeline;
-
-static inline void countRestoreResult(const Reply *reply, MigrationResult *result, int expected) {
-  int i;
-
-  for (i = 0; i < reply->i; ++i) {
-    switch (reply->types[i]) {
-      case STRING:
-        result->copied++;
-        break;
-      case ERR:
-        fprintf(stderr, "%s\n", reply->lines[i]);
-        result->failed++;
-        break;
-      default:
-        result->failed++;
-        break;
-    }
-  }
-
-  if (reply->i < expected) result->failed += expected - reply->i;
-}
-
-static inline void appendRestoreCmd(Pipeline *pip, const char *key, int keySize, const char *payload, int payloadSize) {
-  int j;
-
-  pip->i += snprintf(&pip->buf[pip->i], 12, "*5\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "$7\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "RESTORE\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "$%d\r\n", keySize);
-  pip->i += snprintf(&pip->buf[pip->i], keySize + 3, "%s\r\n", key);
-  pip->i += snprintf(&pip->buf[pip->i], 12, "$1\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "0\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "$%d\r\n", payloadSize);
-  for (j = 0; j < payloadSize; ++j) pip->buf[pip->i++] = payload[j];
-  pip->buf[pip->i++] = '\r';
-  pip->buf[pip->i++] = '\n';
-  pip->i += snprintf(&pip->buf[pip->i], 12, "$7\r\n");
-  pip->i += snprintf(&pip->buf[pip->i], 12, "REPLACE\r\n");
-  pip->cnt++;
-}
-
-static inline void sendResotreCmd(Conn *c, Pipeline *pip, Reply *reply, MigrationResult *result) {
-  pip->buf[pip->i] = '\0';
-  commandWithRawData(c, pip->buf, reply, pip->i);
-  countRestoreResult(reply, result, pip->cnt);
-  pip->cnt = pip->i = 0;
-}
-
-static void transferKeys(Conn *c, const Reply *keys, int first, int size, const Reply *values, MigrationResult *result) {
-  Pipeline pip;
-  Reply reply;
-  int i;
-
-  for (i = pip.cnt = pip.i = 0; i < size; ++i) {
-    if (values->types[i] == NIL) {
-      result->skipped++;
-      continue;
-    }
-
-    appendRestoreCmd(&pip, keys->lines[first+i], keys->sizes[first+i], values->lines[i], values->sizes[i]);
-    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
-
-    sendResotreCmd(c, &pip, &reply, result);
-    freeReply(&reply);
-  }
-}
-
-static void copyKeys(Conn *src, Conn *dest, const Reply *keys, MigrationResult *result) {
-  Pipeline pip;
-  Reply reply;
-  int i, ret, first;
-
-  for (i = first = pip.i = pip.cnt = 0; i < keys->i; ++i) {
-    pip.i += snprintf(&pip.buf[pip.i], MAX_KEY_SIZE * 2, "DUMP %s\r\n", keys->lines[i]);
-    pip.cnt++;
-    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
-
-    pip.buf[pip.i] = '\0';
-    ret = commandWithRawData(src, pip.buf, &reply, pip.i);
-    if (ret == MY_ERR_CODE) {
-      result->failed += pip.cnt;
-    } else {
-      if (pip.cnt != reply.i) {
-        // fprintf(stderr, "%s\n", pip.buf);
-        // printReplyLines(&reply);
-        fprintf(stderr, "RESTORE: keys and dump values are mismatched\n");
-        exit(1);
-      }
-      transferKeys(dest, keys, first, pip.cnt, &reply, result);
-    }
-    pip.cnt = pip.i = 0;
-    first = i + 1;
-    freeReply(&reply);
-  }
-}
-
-static int migrateKeys(const Cluster *src, const Cluster *dest, int slot, int dryRun, MigrationResult *result) {
-  char buf[MAX_CMD_SIZE];
-  int ret;
-  Reply reply;
-
-  ret = countKeysInSlot(FIND_CONN(src, slot), slot);
-  if (ret == MY_ERR_CODE) return ret;
-  if (ret == 0) return MY_OK_CODE;
-  result->found += ret;
-  if (dryRun) return MY_OK_CODE;
-
-  snprintf(buf, MAX_CMD_SIZE, "CLUSTER GETKEYSINSLOT %d %d", slot, ret);
-  ret = command(FIND_CONN(src, slot), buf, &reply);
-  if (ret == MY_ERR_CODE) {
-    freeReply(&reply);
-    return ret;
-  }
-  copyKeys(FIND_CONN(src, slot), FIND_CONN(dest, slot), &reply, result);
-  freeReply(&reply);
-
-  return MY_OK_CODE;
-}
 
 static void *workOnATask(void *args) {
   WorkerArgs *p;

--- a/main.c
+++ b/main.c
@@ -2,7 +2,6 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <signal.h>
-#include <stdint.h>
 #include "./generic.h"
 #include "./net.h"
 #include "./cluster.h"
@@ -20,7 +19,7 @@ static void *workOnATask(void *args) {
 
   p = (WorkerArgs *) args;
   printf("%02d: %lu <%lu>: %05d - %05d\n",
-      p->i, (uint64_t) getpid(), (uint64_t) pthread_self(), p->firstSlot, p->lastSlot);
+      p->i, (unsigned long) getpid(), (unsigned long) pthread_self(), p->firstSlot, p->lastSlot);
   p->result->found = p->result->copied = p->result->skipped = p->result->failed = 0;
   for (i = p->firstSlot; i <= p->lastSlot; ++i) copyKeys(p->src, p->dest, i, p->dryRun, p->result);
   pthread_exit((void *) p->result);

--- a/main.c
+++ b/main.c
@@ -8,13 +8,9 @@
 #include "./command.h"
 #include "./cluster.h"
 
-#define MIGRATE_CMD_TIMEOUT 30000
-
 #ifndef MAX_CONCURRENCY
 #define MAX_CONCURRENCY 4
 #endif // MAX_CONCURRENCY
-
-#define MAX_MIGRATE_CMD_SIZE 2000
 
 #ifndef PIPELINING_SIZE
 #define PIPELINING_SIZE 10
@@ -22,55 +18,89 @@
 
 typedef struct { int copied, skipped, failed, found; } MigrationResult;
 typedef struct { Cluster *src, *dest; int i, firstSlot, lastSlot, dryRun; MigrationResult *result; } WorkerArgs;
-typedef struct { char buf[MAX_MIGRATE_CMD_SIZE * PIPELINING_SIZE]; int i, cnt; } Pipeline;
+typedef struct { char buf[MAX_CMD_SIZE * PIPELINING_SIZE]; int i, cnt; } Pipeline;
 
-static int countKeysInSlot(Conn *conn, int slot) {
-  char buf[MAX_CMD_SIZE], *line;
-  int ret;
-  Reply reply;
+#define ASSERT_MIGRATION_DATA(n, m) do {\
+  if (n != m) {\
+    fprintf(stderr, "RESTORE: keys and dump values are mismatched\n");\
+    exit(1);\
+  }\
+} while (0)
 
-  snprintf(buf, MAX_CMD_SIZE, "CLUSTER COUNTKEYSINSLOT %d", slot);
-  ret = command(conn, buf, &reply);
-  if (ret == MY_ERR_CODE) {
-    freeReply(&reply);
-    return ret;
-  }
-
-  line = LAST_LINE2(reply);
-  ret = line == NULL ? 0 : atoi(line);
-  freeReply(&reply);
-
-  return ret;
-}
-
-static void copyKeys(Conn *c, Pipeline *pip, MigrationResult *result) {
+static void countRestoreResult(const Reply *reply, MigrationResult *result) {
   int i;
-  Reply reply;
 
-  pip->buf[pip->i] = '\0';
-  pipeline(c, pip->buf, &reply, pip->cnt);
-  for (i = 0; i < reply.i; ++i) {
-    if (strncmp(reply.lines[i], "OK", 2) == 0) {
+  for (i = 0; i < reply->i; ++i) {
+    if (strncmp(reply->lines[i], "OK", 2) == 0) {
       result->copied++;
-    } else if (strncmp(reply.lines[i], "NOKEY", 5) == 0) {
-      result->skipped++;
     } else {
       result->failed++;
     }
   }
-  pip->cnt = pip->i = 0;
-  freeReply(&reply);
+}
+
+static void transferKeys(Conn *c, const Reply *keys, const Reply *values, MigrationResult *result) {
+  Pipeline pip;
+  Reply reply;
+  int i, ret;
+
+  ASSERT_MIGRATION_DATA(keys->i, values->i);
+
+  for (i = 0; i < keys->i; ++i) {
+    if (values->types[i] == NIL) {
+      result->skipped++;
+      continue;
+    }
+
+    pip.i += snprintf(&pip.buf[pip.i], MAX_KEY_SIZE * 2 + values->sizes[i],
+        "RESTORE %s 0 \"%s\" REPLACE\r\n", keys->lines[i], values->lines[i]);
+    pip.cnt++;
+    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
+
+    pip.buf[pip.i] = '\0';
+    ret = pipeline(c, pip.buf, &reply, pip.cnt);
+    if (ret == MY_ERR_CODE) {
+      result->failed += pip.cnt;
+    } else {
+      countRestoreResult(&reply, result);
+    }
+    pip.cnt = pip.i = 0;
+    freeReply(&reply);
+  }
+}
+
+static void copyKeys(Conn *src, Conn *dest, const Reply *keys, MigrationResult *result) {
+  Pipeline pip;
+  Reply reply;
+  int i, ret;
+
+  for (i = pip.i = pip.cnt = 0; i < keys->i; ++i) {
+    pip.i += snprintf(&pip.buf[pip.i], MAX_KEY_SIZE * 2, "DUMP %s\r\n", keys->lines[i]);
+    pip.cnt++;
+    if ((i + 1) % PIPELINING_SIZE != 0 && i < keys->i - 1) continue;
+
+    pip.buf[pip.i] = '\0';
+    ret = pipeline(src, pip.buf, &reply, pip.cnt);
+    if (ret == MY_ERR_CODE) {
+      result->failed += pip.cnt;
+    } else {
+      transferKeys(dest, keys, &reply, result);
+    }
+    pip.cnt = pip.i = 0;
+    freeReply(&reply);
+  }
 }
 
 static int migrateKeys(const Cluster *src, const Cluster *dest, int slot, int dryRun, MigrationResult *result) {
   char buf[MAX_CMD_SIZE];
-  int i, ret;
-  Pipeline pip;
+  int ret;
   Reply reply;
 
   ret = countKeysInSlot(FIND_CONN(src, slot), slot);
   if (ret == MY_ERR_CODE) return ret;
   if (ret == 0) return MY_OK_CODE;
+  result->found += ret;
+  if (dryRun) return MY_OK_CODE;
 
   snprintf(buf, MAX_CMD_SIZE, "CLUSTER GETKEYSINSLOT %d %d", slot, ret);
   ret = command(FIND_CONN(src, slot), buf, &reply);
@@ -78,21 +108,9 @@ static int migrateKeys(const Cluster *src, const Cluster *dest, int slot, int dr
     freeReply(&reply);
     return ret;
   }
-
-  for (i = pip.i = pip.cnt = 0; i < reply.i; ++i) {
-    if (dryRun) {
-      result->found++;
-      continue;
-    }
-    pip.i += snprintf(&pip.buf[pip.i], MAX_MIGRATE_CMD_SIZE,
-        "MIGRATE %s %s %s 0 %d COPY REPLACE\r\n",
-        FIND_CONN(dest, slot)->addr.host, FIND_CONN(dest, slot)->addr.port, reply.lines[i], MIGRATE_CMD_TIMEOUT);
-    pip.cnt++;
-    if ((i + 1) % PIPELINING_SIZE == 0) copyKeys(FIND_CONN(src, slot), &pip, result);
-  }
-  if (!dryRun && reply.i % PIPELINING_SIZE != 0) copyKeys(FIND_CONN(src, slot), &pip, result);
-
+  copyKeys(FIND_CONN(src, slot), FIND_CONN(dest, slot), &reply, result);
   freeReply(&reply);
+
   return MY_OK_CODE;
 }
 
@@ -155,13 +173,10 @@ static int migrateKeysPerSlot(const Cluster *src, const Cluster *dest, int dryRu
     sum.failed += results[i].failed;
   }
 
-  if (dryRun) {
-    printf("%d keys were found\n", sum.found);
-  } else {
-    printf("%d keys were copied\n", sum.copied);
-    printf("%d keys were skipped\n", sum.skipped);
-    printf("%d keys were failed\n", sum.failed);
-  }
+  printf("%d keys were found\n", sum.found);
+  printf("%d keys were copied\n", sum.copied);
+  printf("%d keys were skipped\n", sum.skipped);
+  printf("%d keys were failed\n", sum.failed);
 
   for (i = 0; i < MAX_CONCURRENCY; ++i) {
     if (freeClusterState(args[i].src) == MY_ERR_CODE) return MY_ERR_CODE;

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdint.h>
 #include "./generic.h"
 #include "./net.h"
 #include "./cluster.h"
@@ -9,7 +10,7 @@
 
 #ifndef MAX_CONCURRENCY
 #define MAX_CONCURRENCY 4
-#endif // MAX_CONCURRENCY
+#endif  // MAX_CONCURRENCY
 
 typedef struct { Cluster *src, *dest; int i, firstSlot, lastSlot, dryRun; MigrationResult *result; } WorkerArgs;
 
@@ -18,7 +19,8 @@ static void *workOnATask(void *args) {
   int i;
 
   p = (WorkerArgs *) args;
-  printf("%02d: %lu <%lu>: %05d - %05d\n", p->i, (unsigned long) getpid(), (unsigned long) pthread_self(), p->firstSlot, p->lastSlot);
+  printf("%02d: %lu <%lu>: %05d - %05d\n",
+      p->i, (uint64_t) getpid(), (uint64_t) pthread_self(), p->firstSlot, p->lastSlot);
   p->result->found = p->result->copied = p->result->skipped = p->result->failed = 0;
   for (i = p->firstSlot; i <= p->lastSlot; ++i) migrateKeys(p->src, p->dest, i, p->dryRun, p->result);
   pthread_exit((void *) p->result);

--- a/net.c
+++ b/net.c
@@ -4,6 +4,7 @@
 #include <sys/time.h>
 #include <netdb.h>
 #include <unistd.h>
+#include "./generic.h"
 #include "./net.h"
 
 #ifndef MAX_TIMEOUT_SEC

--- a/net.c
+++ b/net.c
@@ -9,7 +9,7 @@
 
 #ifndef MAX_TIMEOUT_SEC
 #define MAX_TIMEOUT_SEC 5
-#endif // MAX_TIMEOUT_SEC
+#endif  // MAX_TIMEOUT_SEC
 
 static int parseAddress(const char *str, HostPort *addr) {
   int len, i, j;
@@ -118,7 +118,7 @@ int freeConnection(Conn *c) {
   if (fclose(c->fw) == EOF) {
     // perror("fclose(3): for write");
     // return MY_ERR_CODE;
-  };
+  }
   c->fw = NULL;
 
   // FIXME: The socket is shared between write and read. So it is already bad descriptor.

--- a/net.h
+++ b/net.h
@@ -1,8 +1,6 @@
 #ifndef NET_H_
 #define NET_H_
 
-#include "./generic.h"
-
 int createConnection(Conn *);
 int createConnectionFromStr(const char *, Conn *);
 int reconnect(Conn *);

--- a/net.h
+++ b/net.h
@@ -12,4 +12,4 @@ int createConnectionFromStr(const char *, Conn *);
 int reconnect(Conn *);
 int freeConnection(Conn *);
 
-#endif // NET_H_
+#endif  // NET_H_

--- a/net.h
+++ b/net.h
@@ -1,6 +1,12 @@
 #ifndef NET_H_
 #define NET_H_
 
+#define MAX_HOST_SIZE 256
+#define MAX_PORT_SIZE 8
+
+typedef struct { char host[MAX_HOST_SIZE], port[MAX_PORT_SIZE]; } HostPort;
+typedef struct { FILE *fw, *fr; HostPort addr; } Conn;
+
 int createConnection(Conn *);
 int createConnectionFromStr(const char *, Conn *);
 int reconnect(Conn *);


### PR DESCRIPTION
We can't use string based functions for `DUMP` and `RESTORE`.

[How to use redis' `DUMP` and `RESTORE` (offline)?](https://stackoverflow.com/questions/16127682/how-to-use-redis-dump-and-restore-offline)